### PR TITLE
Add 3D donut example and improve render viewport resolution

### DIFF
--- a/examples/donut.py
+++ b/examples/donut.py
@@ -1,0 +1,18 @@
+"""3D donut (torus) example for CAD-Query workflow."""
+
+import cadquery as cq
+
+# Create a proper torus (donut) using the revolve method
+# This method creates a true rounded donut by revolving a circle
+major_radius = 15  # Distance from center to tube center
+minor_radius = 3   # Tube radius
+
+result = (cq.Workplane("YZ")
+          .moveTo(major_radius, 0)  # Move to major radius distance from center
+          .circle(minor_radius)     # Create circle with minor radius
+          .revolve(360)             # Revolve 360 degrees around Y-axis to create torus
+         )
+
+# Export the result for cq-cli
+# Note: show_object is provided by CQGI execution environment
+show_object(result)  # noqa: F821

--- a/src/ai_3d_print/render_views.py
+++ b/src/ai_3d_print/render_views.py
@@ -42,7 +42,7 @@ def main() -> bool:
             "--outfile",
             str(output_file),
             "--outputopts",
-            f"projectionDir:{direction};width:400;height:400",
+            f"projectionDir:{direction};width:800;height:800",
         ]
 
         try:


### PR DESCRIPTION
## Summary
- Add comprehensive 3D donut (torus) example using CAD-Query's revolve method
- Improve render viewport resolution from 400x400 to 800x800 for better visual detail
- Confirm that CAD-Query's automatic fit-to-view functionality works correctly for models of any size

## Changes
- **examples/donut.py**: New 3D torus example with proper geometry using revolve method instead of basic cylinder subtraction
- **src/ai_3d_print/render_views.py**: Increased viewport dimensions for higher resolution SVG outputs

## Technical Details
The donut implementation uses CAD-Query's revolve method which creates a true rounded torus by revolving a circle around an axis. This approach provides better geometry than alternative methods like sweep or cylinder subtraction.

The render script improvement addresses viewport resolution while confirming that CAD-Query automatically scales objects to fit any viewport size through dynamic transform calculations.

## Test plan
- [x] Generate donut SVG views with `uv run python src/ai_3d_print/render_views.py examples/donut.py`
- [x] Export STL with `uv run cq-cli --codec stl --infile examples/donut.py --outfile outputs/donut.stl`
- [x] Verify all SVG views show complete torus geometry
- [x] Confirm automatic scaling works for different model sizes
- [x] Validate that pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)